### PR TITLE
Linkjes naar oefeningen

### DIFF
--- a/week2-improved/oop-deel2.html
+++ b/week2-improved/oop-deel2.html
@@ -3644,6 +3644,7 @@
 
 <h1 id="oop-python-methoden-en-inkapseling">OOP Python – Methoden en inkapseling<a class="headerlink" href="#oop-python-methoden-en-inkapseling" title="Permanent link">&para;</a></h1>
 <p>Inkapseling (Engels: <em>encapsulation</em>) is één van de fundamenten van object-georiënteerd programmeren. Het wordt gebruikt om onbevoegden niet de gelegenheid te bieden de kenmerken van een object zomaar aan te passen. Als dat mogelijk moet zijn dan dienen zij toegang te krijgen tot de zogenaamde <code>getters</code> en <code>setters</code>, waarover zo dadelijk meer.</p>
+<p>Aan het eind van deze tekst maken we <a href="oefeningen/oop-oefening1.html">oefening nummer 1</a></p>
 <div class="admonition info">
 <p class="admonition-title">zichtbaarheid</p>
 <p>Python wijkt nadrukkelijk af van het idee van inkapseling zoals het bijvoorbeeld gedaan wordt bij Java. Python gebruikt niet de sleutel-woorden <code>private</code> of <code>protected</code> om de zichtbaarheid van een methode aan te geven.</p>
@@ -3815,7 +3816,7 @@
 <li>Het valideren van input in methoden</li>
 </ul>
 <p>In het volgende deel gaan we kijken naar meerdere klassen die met elkaar samenwerken.</p>
-
+<p>Maak nu <a href="oefeningen/oop-oefening1.html">oefening nummer 1</a></p>
 
 
 

--- a/week2-improved/oop-deel5.html
+++ b/week2-improved/oop-deel5.html
@@ -3652,7 +3652,7 @@
 <div class="highlight"><pre><span></span><code><span class="go">Verzendkosten voor Java voor beginners: €3.95</span>
 </code></pre></div>
 <p>Deze methode is alleen beschikbaar voor de objecten uit de klasse <code>FysiekProduct</code>. Een object uit de klasse <code>Product</code> kan deze methode niet benaderen.</p>
-<p>Maak nu <a href="oefeningen/oop-oefening2-improved.md">oefening nummer 2</a></p>
+<p>Maak nu <a href="oefeningen/oop-oefening2.html">oefening nummer 2</a></p>
 
 
 


### PR DESCRIPTION
Kleine fix

De linkjes naar de oefening 2 van week 2 waren stuk.
Oefening 1 werd niet benoemd in de uitleg. Nu wel.